### PR TITLE
update links on GitHub page

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -15,9 +15,9 @@ There's a lot of single-cell omics file/object formats out there, and not all to
 3. **Save**: Saves the converted file/object (sub-function: `save_data()`).
 
 
-## [Documentation website](https://bschilder.github.io/scKirby)  
-## [Vignette: data ingestion](https://bschilder.github.io/scKirby/articles/scKirby.html)  
-## [Vignette: conda environments](https://bschilder.github.io/scKirby/articles/conda.html)  
+## [Documentation website](https://neurogenomics.github.io/scKirby)  
+## [Vignette: data ingestion](https://neurogenomics.github.io/scKirby/articles/scKirby.html)  
+## [Vignette: conda environments](https://neurogenomics.github.io/scKirby/articles/conda.html)  
 
 # i/o formats 
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ any of these steps separately using the designated sub-functions.
 3.  **Save**: Saves the converted file/object (sub-function:
     `save_data()`).
 
-## [Documentation website](https://bschilder.github.io/scKirby)
+## [Documentation website](https://neurogenomics.github.io/scKirby)
 
-## [Vignette: data ingestion](https://bschilder.github.io/scKirby/articles/scKirby.html)
+## [Vignette: data ingestion](https://neurogenomics.github.io/scKirby/articles/scKirby.html)
 
-## [Vignette: conda environments](https://bschilder.github.io/scKirby/articles/conda.html)
+## [Vignette: conda environments](https://neurogenomics.github.io/scKirby/articles/conda.html)
 
 # i/o formats
 


### PR DESCRIPTION
Hi Brian,

Thank you for the package! Apparently the links on the GitHub page are broken (returns 404. There isn't a GitHub Pages site here. when clicked), this pull request should update the links on that page.

Best regards,


Haries